### PR TITLE
fix for a typo in J_het immersion freezing formula from Seifert & Beheng paper

### DIFF
--- a/scalelib/src/atmosphere/physics/microphysics/scale_atmos_phy_mp_sn14.F90
+++ b/scalelib/src/atmosphere/physics/microphysics/scale_atmos_phy_mp_sn14.F90
@@ -4657,12 +4657,12 @@ contains
        temc = max( tem(k) - T00, temc_min )
        ! These cause from aerosol-droplet interaction.
        ! Bigg(1953) formula, Khain etal.(2000) eq.(4.5), Pruppacher and Klett(1997) eq.(9-48)
-       Jhet =  a_het*exp( -b_het*temc - 1.0_RP )
+       Jhet =  a_het*(exp( -b_het*temc) - 1.0_RP )
        ! These cause in nature.
        ! Cotton and Field 2002, QJRMS. (12)
        if( temc < -65.0_RP )then
           jhom = 10.0_RP**(24.37236_RP)*1.E+3_RP
-          Jhet =  a_het*exp( 65.0_RP*b_het - 1.0_RP ) ! 09/04/14 [Add], fixer T.Mitsui
+          Jhet =  a_het*(exp( 65.0_RP*b_het) - 1.0_RP )
        else if( temc < -30.0_RP ) then
           temc2 = temc*temc
           temc3 = temc*temc2


### PR DESCRIPTION
CC: @nriemer, @s-shima

The Seifer & Beheng 2006 paper (https://doi.org/10.1007/s00703-005-0112-4) seems to include a typo in eq. 44:

![image](https://user-images.githubusercontent.com/89685/127404088-ae23ba9b-406b-4758-afe8-eadbac6ff47e.png)

as the "-1" term should not be under the exponent, as evident from the cited paper of Bigg 1953 (https://doi.org/10.1088/0370-1301/66/8/309):

![image](https://user-images.githubusercontent.com/89685/127404442-3ff4d9ae-56aa-4506-b60d-a1049d42e132.png)

which ensures that the rate J_het is zero if the degree of supercooling is zero.

Even though, the ACP COSMO paper (https://acp.copernicus.org/articles/18/16461/2018/acp-18-16461-2018.pdf) also "features this bug"):

![image](https://user-images.githubusercontent.com/89685/127404763-2e8ffef8-3c86-488a-b21d-d50af1182bc8.png)

in the COSMO implementation of S&B scheme, the "-1" is outside of the exponent:

https://github.com/zdedekind/COSMO_5.4b_SecIce/blob/Zane/src/gscp_cloudice.f90#L1120

BTW, the SCALE-SDM repo also features this bug:
https://github.com/Shima-Lab/SCALE-SDM_BOMEX_Sato2018/blob/master/scalelib/src/atmos-physics/microphysics/scale_atmos_phy_mp_sn14.F90#L3700

HTH,
Sylwester